### PR TITLE
add missing attribute in UserRepresentation schema

### DIFF
--- a/keycloak/12.0-patched.json
+++ b/keycloak/12.0-patched.json
@@ -13536,6 +13536,9 @@
           "enabled": {
             "type": "boolean"
           },
+          "totp": {
+            "type": "boolean"
+          },
           "federatedIdentities": {
             "type": "array",
             "items": {


### PR DESCRIPTION
I am using Keycloak 12.0.2 and generated a jersey2 client with the openapi-generator-maven-plugin. When requesting a user object I got the following Exception:

`com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "totp"`

This patch add the missing property.

Thank you for providing this API!